### PR TITLE
GitHub setups

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Which Issue was this PR made for?
+
+- Closes #
+
+## What is within the scope with this PR
+
+
+## What is NOT in the scope with this PR
+
+### Related Issue
+
+## Other sidenotes that reviewer should be aware of

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: cd ./client & yarn install && yarn build
+      - run: cd ./client && yarn install && yarn build
 
   build-server:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: cd ./client & yarn install && yarn build
+      - run: cd ./server && yarn install && yarn build

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -1,0 +1,14 @@
+name: Checks for build
+'on': pull_request
+jobs:
+  build-client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cd ./client & yarn install && yarn build
+
+  build-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cd ./client & yarn install && yarn build

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: cd ./client && yarn install && yarn build
+        env: 
+          CI: false # TODO: Make this true at some point
 
   build-server:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Issues
- Closes #58 
- Closes #59 

## Expected function
runs `yarn install && yarn build` and checks for any build error when PR is created.

## Things to be aware
- Setting `CI=false` to the client part bc there are a lot of warnings and having `CI=true` treats warnings as errors.
- Ci=true will probably be better, since that kinda keeps the code clean from junks (maybe check #57)